### PR TITLE
Add infra-deployment-update-script to update image tags

### DIFF
--- a/.tekton/tekton-results-api-push.yaml
+++ b/.tekton/tekton-results-api-push.yaml
@@ -19,6 +19,9 @@ spec:
       value: "quay.io/redhat-appstudio/tekton-results-api:{{revision}}"
     - name: dockerfile
       value: images/api/Dockerfile
+    - name: infra-deployment-update-script
+      value: |
+        sed -i -e 's/\(newTag: \).*/\1{{ revision }}/' components/build/tekton-results/kustomization.yaml
   pipelineRef:
     name: docker-build
     bundle: quay.io/redhat-appstudio/hacbs-core-service-templates-bundle:latest


### PR DESCRIPTION
## Chnages

- Tekton Results is now being built in HACBS, so using the latest images
from the HACBS build for both watcher and api
- This tiny script will update the image tags whenever there is a
push to this repository
- Refer: redhat-appstudio/infra-deployments#697

Signed-off-by: Avinal Kumar <avinal@redhat.com>