### PR TITLE
Use `downstream` target branch for StoneSoup

### DIFF
--- a/.tekton/tekton-results-api-pull-request.yaml
+++ b/.tekton/tekton-results-api-pull-request.yaml
@@ -6,8 +6,8 @@ metadata:
   name: tekton-results-api-on-pull-request
   annotations:
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
-    # Use pipelines-svc-0.1-f2134db branch since we are using openshift-pipeline/tektoncd-results and not upstream
-    pipelinesascode.tekton.dev/on-target-branch: "[pipeline-svc-0.1-d8b5946]"
+    # Use downstream branch since we are using openshift-pipeline/tektoncd-results and not upstream
+    pipelinesascode.tekton.dev/on-target-branch: "[downstream]"
     pipelinesascode.tekton.dev/max-keep-runs: "5"
 spec:
   params:

--- a/.tekton/tekton-results-api-push.yaml
+++ b/.tekton/tekton-results-api-push.yaml
@@ -6,8 +6,8 @@ metadata:
   name: tekton-results-api-on-pull-request
   annotations:
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
-    # Use pipelines-svc-0.1-f2134db branch since we are using openshift-pipeline/tektoncd-results and not upstream
-    pipelinesascode.tekton.dev/on-target-branch: "[pipeline-svc-0.1-d8b5946]"
+    # Use downstream branch since we are using openshift-pipeline/tektoncd-results and not upstream
+    pipelinesascode.tekton.dev/on-target-branch: "[downstream]"
     pipelinesascode.tekton.dev/max-keep-runs: "5"
 spec:
   params:

--- a/.tekton/tekton-results-watcher-pull-request.yaml
+++ b/.tekton/tekton-results-watcher-pull-request.yaml
@@ -6,8 +6,8 @@ metadata:
   name: tekton-results-watcher-on-pull-request
   annotations:
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
-    # Use pipelines-svc-0.1-f2134db branch since we are using openshift-pipeline/tektoncd-results and not upstream
-    pipelinesascode.tekton.dev/on-target-branch: "[pipeline-svc-0.1-d8b5946]"
+    # Use downstream branch since we are using openshift-pipeline/tektoncd-results and not upstream
+    pipelinesascode.tekton.dev/on-target-branch: "[downstream]"
     pipelinesascode.tekton.dev/max-keep-runs: "5"
 spec:
   params:

--- a/.tekton/tekton-results-watcher-push.yaml
+++ b/.tekton/tekton-results-watcher-push.yaml
@@ -6,8 +6,8 @@ metadata:
   name: tekton-results-watcher-on-push
   annotations:
     pipelinesascode.tekton.dev/on-event: "[push]"
-    # Use pipelines-svc-0.1-f2134db branch since we are using openshift-pipeline/tektoncd-results and not upstream
-    pipelinesascode.tekton.dev/on-target-branch: "[pipeline-svc-0.1-d8b5946]"
+    # Use downstream branch since we are using openshift-pipeline/tektoncd-results and not upstream
+    pipelinesascode.tekton.dev/on-target-branch: "[downstream]"
     pipelinesascode.tekton.dev/max-keep-runs: "5"
 spec:
   params:


### PR DESCRIPTION
Update our Pipelines as Code definitions to execute against the "downstream" default branch.