### PR TITLE
PLNSRVCE-1104: add update on push pac job to update pipeline-service

### DIFF
--- a/.tekton/tekton-results-api-push.yaml
+++ b/.tekton/tekton-results-api-push.yaml
@@ -19,6 +19,13 @@ spec:
       value: "quay.io/redhat-appstudio/tekton-results-api:{{revision}}"
     - name: dockerfile
       value: images/api/Dockerfile
+    - name: infra-deployment-update-script
+      value: |
+        sed -i -E 's/[0-9a-f]{40}/{{ revision }}/g' operator/gitops/argocd/pipeline-service/tekton-results/base/kustomization.yaml
+    - name: TARGET_GH_REPO
+      value: openshift-pipelines/pipeline-service
+    - name: GITHUB_APP_INSTALLATION_ID
+      value: "28617334"
   pipelineRef:
     name: docker-build
     bundle: quay.io/redhat-appstudio/hacbs-core-service-templates-bundle:latest


### PR DESCRIPTION
trying this first, hoping to approximate https://github.com/redhat-appstudio/jvm-build-service/blob/main/.tekton/controller-push.yaml

fallback will be a separate push job for update a la https://github.com/openshift-pipelines/pipeline-service/blob/main/.tekton/push.yaml

that said, cannot test unlike the pull jobs until after merge