### PR TITLE
STONEBLD-777 - tekton-ci: update bundle

### DIFF
--- a/.tekton/tekton-results-api-pull-request.yaml
+++ b/.tekton/tekton-results-api-pull-request.yaml
@@ -21,7 +21,7 @@ spec:
       value: images/api/Dockerfile
   pipelineRef:
     name: docker-build
-    bundle: quay.io/redhat-appstudio/hacbs-core-service-templates-bundle:latest
+    bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest
   workspaces:
     - name: workspace
       volumeClaimTemplate:

--- a/.tekton/tekton-results-api-push.yaml
+++ b/.tekton/tekton-results-api-push.yaml
@@ -21,7 +21,7 @@ spec:
       value: images/api/Dockerfile
   pipelineRef:
     name: docker-build
-    bundle: quay.io/redhat-appstudio/hacbs-core-service-templates-bundle:latest
+    bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest
   workspaces:
     - name: workspace
       volumeClaimTemplate:

--- a/.tekton/tekton-results-update-pipeline-service.yaml
+++ b/.tekton/tekton-results-update-pipeline-service.yaml
@@ -41,5 +41,5 @@ spec:
           - name: GITHUB_APP_INSTALLATION_ID
             value: "28617334"
         taskRef:
-          bundle: quay.io/redhat-appstudio/appstudio-tasks:748a03507b68aa610212e8031e3301ab943a14ef-2
+          bundle: quay.io/redhat-appstudio-tekton-catalog/task-update-infra-deployments:0.1
           name: update-infra-deployments

--- a/.tekton/tekton-results-watcher-pull-request.yaml
+++ b/.tekton/tekton-results-watcher-pull-request.yaml
@@ -21,7 +21,7 @@ spec:
       value: images/watcher/Dockerfile
   pipelineRef:
     name: docker-build
-    bundle: quay.io/redhat-appstudio/hacbs-core-service-templates-bundle:latest
+    bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest
   workspaces:
     - name: workspace
       volumeClaimTemplate:

--- a/.tekton/tekton-results-watcher-push.yaml
+++ b/.tekton/tekton-results-watcher-push.yaml
@@ -21,7 +21,7 @@ spec:
       value: images/watcher/Dockerfile
   pipelineRef:
     name: docker-build
-    bundle: quay.io/redhat-appstudio/hacbs-core-service-templates-bundle:latest
+    bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest
   workspaces:
     - name: workspace
       volumeClaimTemplate:


### PR DESCRIPTION
Switching to new bundle since development of old one was stopped before attempt to migrate to kcp. New bundle is removing dependency on shared secret.

This requires to install https://github.com/apps/red-hat-appstudio-ci-cd