### PR TITLE
Fix pipeline webhook validation error

### DIFF
--- a/pkg/watcher/reconciler/annotation/annotation.go
+++ b/pkg/watcher/reconciler/annotation/annotation.go
@@ -17,6 +17,7 @@ package annotation
 import (
 	"encoding/json"
 
+	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -46,18 +47,24 @@ const (
 	ChildReadyForDeletion = "results.tekton.dev/childReadyForDeletion"
 )
 
+// TaskRunSpec Fix for spec.resources webhook validation in v1 APIs
+type taskRunSpec struct {
+	Resources *pipelinev1beta1.TaskResources `json:"resources"`
+}
+
 // Annotation is wrapper for Kubernetes resource annotations stored in the metadata.
 type Annotation struct {
 	Name  string
 	Value string
 }
 
-type mergePatch struct {
-	Metadata metadata `json:"metadata"`
-}
-
 type metadata struct {
 	Annotations map[string]string `json:"annotations"`
+}
+
+type mergePatch struct {
+	Metadata metadata    `json:"metadata"`
+	Spec     taskRunSpec `json:"spec"`
 }
 
 // Patch creates a jsonpatch path used for adding result / record identifiers as
@@ -67,6 +74,8 @@ func Patch(object metav1.Object, annotations ...Annotation) ([]byte, error) {
 		Metadata: metadata{
 			Annotations: map[string]string{},
 		},
+		// Fix for spec.resources webhook validation in v1 APIs
+		Spec: taskRunSpec{Resources: nil},
 	}
 
 	for _, annotation := range annotations {


### PR DESCRIPTION
# Changes

Fix Tekton Pipelines webhook validation error with v1 APIs when TaskRun have `spec.resources` field set.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
