### PR TITLE
fix kustomize warning messages

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -23,8 +23,8 @@ resources:
 - config-logging.yaml
 - config-observability.yaml
 
-patchesStrategicMerge:
-  - migrator.yaml
+patches:
+  - path: migrator.yaml
 
 configMapGenerator:
   # Create a ConfigMap containing the API configs.


### PR DESCRIPTION
This PR fixes the warning message while running `kustomize build`. This was happening because we have added a patch to include migration YAML.