### PR TITLE
DO NOT MERGE, CI ONLY: Downstream 0.9.1 04

### DIFF
--- a/pkg/watcher/reconciler/dynamic/dynamic.go
+++ b/pkg/watcher/reconciler/dynamic/dynamic.go
@@ -18,6 +18,9 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
+	"runtime/pprof"
+	"strings"
 	"time"
 
 	"github.com/fatih/color"
@@ -36,6 +39,8 @@ import (
 	"github.com/tektoncd/results/pkg/watcher/results"
 	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
 	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -89,10 +94,67 @@ func NewDynamicReconciler(rc pb.ResultsClient, lc pb.LogsClient, oc ObjectClient
 	}
 }
 
+func printGoroutines(logger *zap.SugaredLogger, o results.Object) {
+	// manual testing has confirmed you don't have to explicitly enable pprof to get goroutine dumps with
+	// stack traces; this lines up with the stack traces you receive if a panic occurs, as well as the
+	// stack trace you receive if you send a SIGQUIT and/or SIGABRT to a running go program
+	profile := pprof.Lookup("goroutine")
+	if profile == nil {
+		logger.Warnw("Leaving dynamic Reconciler only after context timeout, number of profiles found",
+			zap.String("namespace", o.GetNamespace()),
+			zap.String("kind", o.GetObjectKind().GroupVersionKind().Kind),
+			zap.String("name", o.GetName()))
+	} else {
+		err := profile.WriteTo(os.Stdout, 2)
+		if err != nil {
+			logger.Errorw("problem writing goroutine dump",
+				zap.String("error", err.Error()),
+				zap.String("namespace", o.GetNamespace()),
+				zap.String("kind", o.GetObjectKind().GroupVersionKind().Kind),
+				zap.String("name", o.GetName()))
+		}
+	}
+
+}
+
 // Reconcile handles result/record uploading for the given Run object.
 // If enabled, the object may be deleted upon successful result upload.
 func (r *Reconciler) Reconcile(ctx context.Context, o results.Object) error {
-	logger := logging.FromContext(ctx)
+	dynamicContext, dynamicCancel := context.WithTimeout(ctx, 5*time.Minute)
+	// we dont defer the dynamicCancle because golang defers follow a LIFO pattern
+	// and we want to have our context analysis defer function be able to distinguish between
+	// the context channel being closed because of Canceled or DeadlineExceeded
+	logger := logging.FromContext(dynamicContext)
+	defer func() {
+		ctxErr := dynamicContext.Err()
+		if ctxErr == nil {
+			logger.Warnw("Leaving dynamic Reconciler somehow but the context channel is not closed",
+				zap.String("namespace", o.GetNamespace()),
+				zap.String("kind", o.GetObjectKind().GroupVersionKind().Kind),
+				zap.String("name", o.GetName()))
+			return
+		}
+		if ctxErr == context.Canceled {
+			logger.Infow("Leaving dynamic Reconciler normally with context properly canceled",
+				zap.String("namespace", o.GetNamespace()),
+				zap.String("kind", o.GetObjectKind().GroupVersionKind().Kind),
+				zap.String("name", o.GetName()))
+			return
+		}
+		if ctxErr == context.DeadlineExceeded {
+			logger.Warnw("Leaving dynamic Reconciler only after context timeout, initiating thread dump",
+				zap.String("namespace", o.GetNamespace()),
+				zap.String("kind", o.GetObjectKind().GroupVersionKind().Kind),
+				zap.String("name", o.GetName()))
+			printGoroutines(logger, o)
+			return
+		}
+		logger.Warnw("Leaving dynamic Reconciler with unexpected error",
+			zap.String("error", ctxErr.Error()),
+			zap.String("namespace", o.GetNamespace()),
+			zap.String("kind", o.GetObjectKind().GroupVersionKind().Kind),
+			zap.String("name", o.GetName()))
+	}()
 
 	if o.GetObjectKind().GroupVersionKind().Empty() {
 		gvk, err := convert.InferGVK(o)
@@ -110,18 +172,28 @@ func (r *Reconciler) Reconcile(ctx context.Context, o results.Object) error {
 
 	if err != nil {
 		logger.Debugw("Error upserting record to API server", zap.Error(err), timeTakenField)
+		// in case a call to cancel overwrites the error set in the context
+		if status.Code(err) == codes.DeadlineExceeded {
+			printGoroutines(logger, o)
+		}
+		dynamicCancel()
 		return fmt.Errorf("error upserting record: %w", err)
 	}
 
 	// Update logs if enabled.
 	if r.resultsClient.LogsClient != nil {
-		if err := r.sendLog(ctx, o); err != nil {
+		if err = r.sendLog(ctx, o); err != nil {
 			logger.Errorw("Error sending log",
 				zap.String("namespace", o.GetNamespace()),
 				zap.String("kind", o.GetObjectKind().GroupVersionKind().Kind),
 				zap.String("name", o.GetName()),
 				zap.Error(err),
 			)
+			// in case a call to cancel overwrites the error set in the context
+			if status.Code(err) == codes.DeadlineExceeded {
+				printGoroutines(logger, o)
+			}
+			dynamicCancel()
 			return err
 		}
 	}
@@ -132,11 +204,19 @@ func (r *Reconciler) Reconcile(ctx context.Context, o results.Object) error {
 
 	recordAnnotation := annotation.Annotation{Name: annotation.Record, Value: rec.GetName()}
 	resultAnnotation := annotation.Annotation{Name: annotation.Result, Value: res.GetName()}
-	if err := r.addResultsAnnotations(logging.WithLogger(ctx, logger), o, recordAnnotation, resultAnnotation); err != nil {
+	if err = r.addResultsAnnotations(logging.WithLogger(ctx, logger), o, recordAnnotation, resultAnnotation); err != nil {
+		// no grpc calls from addResultsAnnotation
+		dynamicCancel()
 		return err
 	}
 
-	return r.deleteUponCompletion(logging.WithLogger(ctx, logger), o)
+	if err = r.deleteUponCompletion(logging.WithLogger(dynamicContext, logger), o); err != nil {
+		// no grpc calls from addResultsAnnotation
+		dynamicCancel()
+		return err
+	}
+	dynamicCancel()
+	return nil
 }
 
 // addResultsAnnotations adds Results annotations to the object in question if
@@ -436,10 +516,24 @@ func (r *Reconciler) streamLogs(ctx context.Context, o results.Object, logType, 
 		logger.Error(flushErr)
 		return flushErr
 	}
-	if closeErr := logsClient.CloseSend(); closeErr != nil {
-		logger.Warnw("CloseSend ret err",
+	// so we use CloseAndRecv vs. just CloseSent to achieve a few things:
+	// 1) CloseAndRecv calls CloseSend under the covers, followed by a Recv call to obtain a LogSummary
+	// 2) LogSummary appears to have some stats on the state of operations
+	// 3) It also appears to be the best form of "confirmation" that the asynchronous operation of UpdateLog on the api
+	// server side has reached a terminal state
+	// 4) Hence, creating a child context which we cancel hopefully does not interrupt the UpdateLog call when this method exits,
+	// 5) However, we need the context cancel to close out the last goroutine launched in newClientStreamWithParams that does
+	// the final clean, otherwise we end up with our now familiar goroutine leak, which in the end is a memory leak
+
+	// comparing closeErr with io.EOF does not work; and I could not find code / desc etc. constants in the grpc code that handled
+	// the wrapped EOF error we expect to get from grpc when things are "OK"
+	if logSummary, closeErr := logsClient.CloseAndRecv(); closeErr != nil && !strings.Contains(closeErr.Error(), "EOF") {
+		logger.Warnw("CloseAndRecv ret err",
 			zap.String("name", o.GetName()),
 			zap.String("error", closeErr.Error()))
+		if logSummary != nil {
+			logger.Errorw("CloseAndRecv", zap.String("logSummary", logSummary.String()))
+		}
 		logger.Error(closeErr)
 		return closeErr
 	}


### PR DESCRIPTION
# Changes

temporary commit in lieu of https://github.com/tektoncd/results/pull/725 merging upstream that should conceivably
- free up any dynamic reconciler threads blocked by grpc or tkn calls, with their respective complicated threading models
-  get us a goroutine dump so that we can diagnose long term

# Breaking Changes

None

# Changes that require updates to our downstream configuration

None

@openshift-pipelines/pipelines-service FYI