### PR TITLE
SRVKP-5832: move to downstream images to quay.io/konflux-ci

### DIFF
--- a/.tekton/tekton-results-api-pull-request.yaml
+++ b/.tekton/tekton-results-api-pull-request.yaml
@@ -16,7 +16,7 @@ spec:
     - name: revision
       value: "{{revision}}"
     - name: output-image
-      value: "quay.io/redhat-appstudio/pull-request-builds:tekton-results-api-{{revision}}"
+      value: "quay.io/konflux-ci/pull-request-builds:tekton-results-api-{{revision}}"
     - name: dockerfile
       value: images/api/Dockerfile
   pipelineRef:

--- a/.tekton/tekton-results-api-push.yaml
+++ b/.tekton/tekton-results-api-push.yaml
@@ -16,7 +16,7 @@ spec:
     - name: revision
       value: "{{revision}}"
     - name: output-image
-      value: "quay.io/redhat-appstudio/tekton-results-api:{{revision}}"
+      value: "quay.io/konflux-ci/tekton-results-api:{{revision}}"
     - name: dockerfile
       value: images/api/Dockerfile
   pipelineRef:

--- a/.tekton/tekton-results-watcher-pull-request.yaml
+++ b/.tekton/tekton-results-watcher-pull-request.yaml
@@ -16,7 +16,7 @@ spec:
     - name: revision
       value: "{{revision}}"
     - name: output-image
-      value: "quay.io/redhat-appstudio/pull-request-builds:tekton-results-watcher-{{revision}}"
+      value: "quay.io/konflux-ci/pull-request-builds:tekton-results-watcher-{{revision}}"
     - name: dockerfile
       value: images/watcher/Dockerfile
   pipelineRef:

--- a/.tekton/tekton-results-watcher-push.yaml
+++ b/.tekton/tekton-results-watcher-push.yaml
@@ -16,7 +16,7 @@ spec:
     - name: revision
       value: "{{revision}}"
     - name: output-image
-      value: "quay.io/redhat-appstudio/tekton-results-watcher:{{revision}}"
+      value: "quay.io/konflux-ci/tekton-results-watcher:{{revision}}"
     - name: dockerfile
       value: images/watcher/Dockerfile
   pipelineRef:


### PR DESCRIPTION
Konflux wants us to start using https://quay.io/repository/konflux-ci/tekton-results-watcher and https://quay.io/repository/konflux-ci/tekton-results-api based on the work from Ralph earlier this year.

I am following the pattern @enarha did with https://github.com/openshift-pipelines/tektoncd-results/pull/69